### PR TITLE
cdb now successfully imports on both pypy and cpython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ fast lookups and atomic updates.  This module mimics the normal
 cdb utilities, cdb(get|dump|make), via convenient, high-level Python
 objects.''',
         ext_modules = [ Extension(
-                            "cdbmodule",
+                            "cdb",
                             SRCFILES,
                             include_dirs=[ SRCDIR + '/' ],
                             extra_compile_args=['-fPIC'],


### PR DESCRIPTION
Allow python-cdb to correctly import on both pypy and cpython. Verified that it is now importable.

See drolando's issue and chriskuehl's comment here:
https://github.com/acg/python-cdb/issues/6